### PR TITLE
AL-2552 - Add support to custom VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,9 @@ module "terraform-dome9-awp-aws" {
 
 | Name | Description |
 |------|-------------|
-| <a name="output_account_issues"></a> [account\_issues](#output\_account\_issues) | Indicates if there are any issues with AWP in the account |
 | <a name="output_agentless_protection_enabled"></a> [agentless\_protection\_enabled](#output\_agentless\_protection\_enabled) | AWP Status |
 | <a name="output_awp_cross_account_role_arn"></a> [awp\_cross\_account\_role\_arn](#output\_awp\_cross\_account\_role\_arn) | Value of the cross account role arn that AWP assumes to scan the account |
-| <a name="output_cloud_account_id"></a> [cloud\_account\_id](#output\_cloud\_account\_id) | Cloud Guard account ID |
+| <a name="output_cloud_account_id"></a> [cloud\_account\_id](#output\_cloud\_account\_id) | CloudGuard account ID |
 | <a name="output_missing_awp_private_network_regions"></a> [missing\_awp\_private\_network\_regions](#output\_missing\_awp\_private\_network\_regions) | List of regions in which AWP has issue to create virtual private network (VPC) |
 | <a name="output_should_update"></a> [should\_update](#output\_should\_update) | This module is out of date and should be updated to the latest version. |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module "terraform-dome9-awp-aws" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=5.30.0 |
-| <a name="requirement_dome9"></a> [dome9](#requirement\_dome9) | >=1.32.0 |
+| <a name="requirement_dome9"></a> [dome9](#requirement\_dome9) | >=1.35.8 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | >=3.4.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >=2.5.1 |
 <!-- END_TF_HEADER_DOCS -->

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ module "terraform-dome9-awp-aws" {
 |------|-------------|------|---------|:--------:|:--------:|
 | <a name="input_scan_machine_interval_in_hours"></a> [scan_machine_interval_in_hours](#input\_scan\_machine\_interval\_in\_hours) | Scan machine interval in hours | `number` | `24` | InAccount: `>=4`, SaaS: `>=24` | no |
 | <a name="input_max_concurrent_scans_per_region"></a> [max_concurrent_scans_per_region](#input\_max\_concurrent\_scans\_per\_region) | Maximum concurrent scans per region | `number` | `20` | `1` - `20` | no |
+| <a name="input_in_account_scanner_vpc"></a> [in_account_scanner_vpc](#input\_in\_account\_scanner\_vpc) |  The VPC Mode | `string` | `ManagedByAWP` | `ManagedByAWP`,`ManagedByCustomer` | no |
 | <a name="input_custom_tags"></a> [custom_tags](#input\_custom\_tags) | Custom tags to be added to AWP resources that are created during the scan process | `map(string)` | `{}` | `{"key" = "value", ...}` | no |
 | <a name="input_disabled_regions"></a> [disabled_regions](#input\_disabled\_regions) | List of AWS regions to disable AWP scanning | `list(string)` | `[]` | `["us-east-1", ...]`| no |
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ module "terraform-dome9-awp-aws" {
   awp_account_settings_aws = {
     scan_machine_interval_in_hours  = 24
     max_concurrent_scans_per_region = 20
+    in_account_scanner_vpc          = "ManagedByAWP"
     disabled_regions                = []   # e.g ["ap-northeast-1", "ap-northeast-2"]
     custom_tags                     = {}   # e.g {"key1" = "value1", "key2" = "value2"} 
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -60,6 +60,7 @@ module "terraform-dome9-awp-aws" {
     scan_machine_interval_in_hours  = 24
     disabled_regions                = [] # e.g ["us-east-1", "us-west-2"]
     max_concurrent_scans_per_region = 20
+    in_account_scanner_vpc          = "ManagedByAWP"
     custom_tags = {
       tag1 = "value1"
       tag2 = "value2"

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -25,7 +25,3 @@ output "missing_awp_private_network_regions" {
   value       = module.terraform-dome9-awp-aws[0].missing_awp_private_network_regions
 }
 
-output "account_issues" {
-  description = "Indicates if there are any issues with AWP in the account"
-  value       = module.terraform-dome9-awp-aws[0].account_issues
-}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     dome9 = {
       source = "dome9/dome9"
-      version = ">=1.32.0"
+      version = ">=1.35.8"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,8 +22,3 @@ output "missing_awp_private_network_regions" {
   description = "List of regions in which AWP has issue to create virtual private network (VPC)"
   value       = resource.dome9_awp_aws_onboarding.awp_aws_onboarding_resource.missing_awp_private_network_regions
 }
-
-output "account_issues" {
-  description = "Indicates if there are any issues with AWP in the account"
-  value       = resource.dome9_awp_aws_onboarding.awp_aws_onboarding_resource.account_issues
-}

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "awp_account_settings_aws" {
     disabled_regions                = optional(list(string)) # List of regions to disable scanning e.g. ["us-east-1", "us-west-2"]
     scan_machine_interval_in_hours  = optional(number)       # Scan machine interval in hours
     max_concurrent_scans_per_region = optional(number)       # Maximum concurrence scans per region
-    in_account_scanner_vpc          = optional(string)       # The VPC Mode. Valid values: "ManagedByAWP", "ManagedByCustomer"
+    in_account_scanner_vpc          = optional(string)       # The VPC Mode. Valid values: "ManagedByAWP", "ManagedByCustomer"  (supported for inAccount and inAccountHub scan modes)
     custom_tags                     = optional(map(string))  # Custom tags to be added to AWP resources e.g. {"key1" = "value1", "key2" = "value2"}
   })
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,7 @@ variable "awp_account_settings_aws" {
     disabled_regions                = optional(list(string)) # List of regions to disable scanning e.g. ["us-east-1", "us-west-2"]
     scan_machine_interval_in_hours  = optional(number)       # Scan machine interval in hours
     max_concurrent_scans_per_region = optional(number)       # Maximum concurrence scans per region
+    in_account_scanner_vpc          = optional(string)       # The VPC Mode. Valid values: "ManagedByAWP", "ManagedByCustomer"
     custom_tags                     = optional(map(string))  # Custom tags to be added to AWP resources e.g. {"key1" = "value1", "key2" = "value2"}
   })
   default = {}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     dome9 = {
       source  = "dome9/dome9"
-      version = ">=1.32.0"
+      version = ">=1.35.8"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
CloudGuard AWP (AWS) - Terraform Module

This pull request introduces the implementation of AWP custom VPC for AWS

This pull request adds the ability to set the in account scanner VPC mode.

for more info please visit
(https://www.checkpoint.com/dome9/)

This module uses [Check Point CloudGuard Dome9 Provider](https://registry.terraform.io/providers/dome9/dome9/latest/docs)