### PR TITLE
AL-2552 - Add support to new awp tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,7 @@ locals {
 
   common_tags = merge({
     Owner                     = "CG.AWP"
+    CG_AWP_OWNER              = "CG.AWP"
     Terraform                 = "true"
     "CG.AL.TF.MODULE_VERSION" = local.awp_module_version
   }, var.awp_additional_tags != null ? var.awp_additional_tags : {})


### PR DESCRIPTION
CloudGuard AWP (AWS) - Terraform Module

This pull request adds the new Owner Tag to resources created in AWS.

for more info please visit
(https://www.checkpoint.com/dome9/)

This module uses [Check Point CloudGuard Dome9 Provider](https://registry.terraform.io/providers/dome9/dome9/latest/docs)